### PR TITLE
add check for macos in aws-vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ You will need a [Powerline-patched font][btf-patching] for this to work, unless 
 
 This theme is based loosely on [agnoster][btf-agnoster].
 
+For MacOS install coreutils to get gdate as date has a different syntax. This is required for aws-vault and awsume support in the bobthefish prompt on MacOS. 
 
+    brew intall coreutils
+    
 ### Features
 
  * A helpful, but not too distracting, greeting.
@@ -130,6 +133,7 @@ set -g theme_newline_prompt '$ '
 - `theme_display_k8s_context`. This feature is disabled by default. Use `yes` to show the current kubernetes context (`> kubectl config current-context`).
 - `theme_display_k8s_namespace`. This feature is disabled by default. Use `yes` to show the current kubernetes namespace.
 - `theme_display_aws_vault_profile`. This feature is disabled by default. Use `yes` to show the currently executing [AWS Vault](https://github.com/99designs/aws-vault) profile.
+- `theme_display_awsume_profile`. This feature is disabled by default. Use `yes` to show the currently executing awsume profile.
 - `theme_display_user`. If set to `yes`, display username always, if set to `ssh`, only when an SSH-Session is detected, if set to no, never.
 - `theme_display_hostname`. Same behaviour as `theme_display_user`.
 - `theme_display_sudo_user`. If set to `yes`, displays the sudo-username in a root shell. For example, when calling `sudo -s` and having this option set to `yes`, the username of the user, who called `sudo -s`, will be displayed.

--- a/functions/fish_prompt.fish
+++ b/functions/fish_prompt.fish
@@ -662,10 +662,15 @@ function __bobthefish_prompt_aws_vault_profile -S -d 'Show AWS Vault profile'
     [ -n "$AWS_VAULT" -a -n "$AWS_SESSION_EXPIRATION" ]
     or return
 
+    if test (uname) = Darwin
+           set  now (gdate --utc +%s)
+           set  expiry (gdate -d "$AWS_SESSION_EXPIRATION" +%s)
+    else
+           set  now (date --utc +%s)
+           set  expiry (date -d "$AWS_SESSION_EXPIRATION" +%s)
+    end
+    
     set -l profile $AWS_VAULT
-
-    set -l now (date --utc +%s)
-    set -l expiry (date -d "$AWS_SESSION_EXPIRATION" +%s)
     set -l diff_mins (math "floor(( $expiry - $now ) / 60)")
 
     set -l diff_time $diff_mins"m"


### PR DESCRIPTION
use gdate instead of date due to difference in syntax